### PR TITLE
Adjustments from brukertest

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,0 +1,16 @@
+import { KABIN_API_BASE_PATH } from '../simple-api-state/use-api';
+import { Create } from '../types/create';
+
+export const editTitle = async (tittel: string, journalpostId: string, dokumentInfoId: string) =>
+  fetch(`${KABIN_API_BASE_PATH}/journalposter/${journalpostId}/dokumenter/${dokumentInfoId}/tittel`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tittel }),
+  });
+
+export const createAnke = async (anke: Create) =>
+  fetch(`${KABIN_API_BASE_PATH}/createanke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(anke),
+  });

--- a/frontend/src/components/ankemuligheter/ankemulighet.tsx
+++ b/frontend/src/components/ankemuligheter/ankemulighet.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export const Ankemulighet = ({ ankemulighet }: Props) => {
-  const { ankemulighet: selectedAnkemulighet, setAnkemulighet } = useContext(AnkeContext);
+  const { ankemulighet: selectedAnkemulighet, setAnkemulighet, setKlager } = useContext(AnkeContext);
   const utfallName = useUtfallName(ankemulighet.utfallId);
   const ytelseName = useYtelseName(ankemulighet.ytelseId);
 
@@ -26,8 +26,9 @@ export const Ankemulighet = ({ ankemulighet }: Props) => {
     (e: React.MouseEvent) => {
       e.stopPropagation();
       setAnkemulighet(ankemulighet);
+      setKlager(ankemulighet.klager);
     },
-    [ankemulighet, setAnkemulighet]
+    [ankemulighet, setAnkemulighet, setKlager]
   );
 
   return (

--- a/frontend/src/components/date-picker/date-picker.tsx
+++ b/frontend/src/components/date-picker/date-picker.tsx
@@ -55,8 +55,8 @@ export const Datepicker = ({
   const [month, setMonth] = useState(value);
 
   const validateDate = useCallback(
-    (dateObject: Date | undefined): boolean => {
-      const isValidDate = dateObject !== undefined && isValid(dateObject);
+    (dateObject: Date): boolean => {
+      const isValidDate = isValid(dateObject);
 
       if (!isValidDate) {
         setInputError('Ugyldig dato');
@@ -91,7 +91,9 @@ export const Datepicker = ({
   );
 
   useEffect(() => {
-    validateDate(value);
+    if (typeof value !== 'undefined') {
+      validateDate(value);
+    }
   }, [value, validateDate]);
 
   const onBlur = useCallback(() => {
@@ -101,6 +103,7 @@ export const Datepicker = ({
 
       return;
     }
+
     requestAnimationFrame(() => {
       const dateString = parseUserInput(input, fromDate, toDate, centuryThreshold);
 

--- a/frontend/src/components/document-viewer/document-title.tsx
+++ b/frontend/src/components/document-viewer/document-title.tsx
@@ -1,160 +1,70 @@
-import { Cancel, Edit, SuccessStroke } from '@navikt/ds-icons';
-import { Button, Heading, TextField } from '@navikt/ds-react';
-import React, { useCallback, useContext, useState } from 'react';
+import { Edit, ExternalLink } from '@navikt/ds-icons';
+import { Button, Heading } from '@navikt/ds-react';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { AnkeContext } from '../../pages/create/anke-context';
+import { usePrevious } from '../../hooks/use-previous';
 import { DocumentViewerContext } from '../../pages/create/document-viewer-context';
-import { KABIN_API_BASE_PATH, useDokumenter } from '../../simple-api-state/use-api';
-import { isApiError } from '../footer/error-type-guard';
-import { errorToast } from '../toast/error-toast';
-import { toast } from '../toast/store';
-import { ToastType } from '../toast/types';
+import { EditTitle } from './edit-document-title';
 
-export const DocumentTitle = () => {
+interface Props {
+  url: string;
+}
+
+export const DocumentTitle = ({ url }: Props) => {
   const [editMode, setEditMode] = useState(false);
+  const { dokument } = useContext(DocumentViewerContext);
+  const previous = usePrevious(dokument);
+
+  useEffect(() => {
+    if (dokument !== previous) {
+      setEditMode(false);
+    }
+  }, [dokument, previous]);
+
+  if (dokument === null) {
+    return null;
+  }
 
   const toggleEditMode = () => setEditMode(!editMode);
 
   return (
     <StyledDocumentTitle>
+      <Button
+        as="a"
+        variant="tertiary"
+        icon={<ExternalLink title="Åpne i nytt vindu" />}
+        size="small"
+        href={url}
+        target="_blank"
+        rel="noreferrer"
+      />
       <ViewTitle show={!editMode} toggleEditMode={toggleEditMode} />
       <EditTitle show={editMode} toggleEditMode={toggleEditMode} />
     </StyledDocumentTitle>
   );
 };
 
-interface ViewTitleProps {
+interface TitleProps {
   show: boolean;
   toggleEditMode: () => void;
 }
 
-const ViewTitle = ({ show, toggleEditMode }: ViewTitleProps) => {
+const ViewTitle = ({ show, toggleEditMode }: TitleProps) => {
   const { dokument } = useContext(DocumentViewerContext);
 
   if (!show) {
     return null;
   }
 
-  const { tittel: title } = dokument;
-
   return (
     <>
       <StyledHeading size="small" level="1">
-        {title}
+        {dokument?.tittel ?? ''}
       </StyledHeading>
       <Button variant="tertiary" icon={<Edit title="Endre dokumenttittel" />} size="small" onClick={toggleEditMode} />
     </>
   );
 };
-
-interface EditTitleProps {
-  show: boolean;
-  toggleEditMode: () => void;
-}
-
-const EditTitle = ({ show, toggleEditMode }: EditTitleProps) => {
-  const { dokument, viewDokument } = useContext(DocumentViewerContext);
-  const { fnr } = useContext(AnkeContext);
-
-  const { updateData: updateDokumenter } = useDokumenter(fnr);
-
-  const { tittel: title, dokumentInfoId, journalpostId } = dokument;
-
-  const [newTitle, setNewTitle] = useState(title ?? '');
-  const [isLoading, setIsLoading] = useState(false);
-
-  const onSaveClick = useCallback(async () => {
-    setIsLoading(true);
-
-    try {
-      const res = await editTitle(newTitle, journalpostId, dokumentInfoId);
-
-      if (res.ok) {
-        toast({ type: ToastType.SUCCESS, message: `Dokumenttittel endret` });
-
-        viewDokument({ ...dokument, tittel: newTitle });
-
-        updateDokumenter((data) =>
-          data === undefined
-            ? undefined
-            : {
-                ...data,
-                dokumenter: data.dokumenter.map((doc) =>
-                  doc.journalpostId === journalpostId
-                    ? {
-                        ...doc,
-                        tittel: doc.dokumentInfoId === dokumentInfoId ? newTitle : doc.tittel,
-                        vedlegg: doc.vedlegg.map((v) =>
-                          v.dokumentInfoId === dokumentInfoId ? { ...v, tittel: newTitle } : v
-                        ),
-                      }
-                    : doc
-                ),
-              }
-        );
-      } else {
-        const json = (await res.json()) as unknown;
-
-        if (isApiError(json)) {
-          errorToast(json);
-        }
-      }
-    } catch (e) {
-      if (e instanceof Error) {
-        toast({ type: ToastType.ERROR, message: `Feil ved endring av dokumenttittel: ${e.message}` });
-      }
-    }
-
-    setIsLoading(false);
-    toggleEditMode();
-  }, [toggleEditMode, newTitle, journalpostId, dokumentInfoId, viewDokument, dokument, updateDokumenter]);
-
-  const isChanged = title !== newTitle;
-
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        isChanged ? onSaveClick() : toggleEditMode();
-      }
-
-      if (e.key === 'Escape') {
-        toggleEditMode();
-      }
-    },
-    [isChanged, onSaveClick, toggleEditMode]
-  );
-
-  if (!show) {
-    return null;
-  }
-
-  return (
-    <>
-      <StyledTextField
-        value={newTitle}
-        onChange={({ target }) => setNewTitle(target.value)}
-        label="Endre tittel"
-        size="small"
-        hideLabel
-        autoFocus
-        onKeyDown={onKeyDown}
-      />
-      <Button
-        variant="tertiary"
-        size="small"
-        icon={<SuccessStroke title="Lagre" />}
-        onClick={isChanged ? onSaveClick : toggleEditMode}
-        loading={isLoading}
-      />
-      <Button variant="tertiary" size="small" icon={<Cancel title="Avbryt" />} onClick={toggleEditMode} />
-    </>
-  );
-};
-
-const StyledTextField = styled(TextField)`
-  width: 100%;
-  flex-grow: 1;
-`;
 
 const StyledHeading = styled(Heading)`
   width: 100%;
@@ -168,10 +78,3 @@ const StyledDocumentTitle = styled.div`
   gap: 8px;
   width: 100%;
 `;
-
-const editTitle = async (tittel: string, journalpostId: string, dokumentInfoId: string) =>
-  fetch(`${KABIN_API_BASE_PATH}/journalposter/${journalpostId}/dokumenter/${dokumentInfoId}/tittel`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ tittel }),
-  });

--- a/frontend/src/components/document-viewer/document-viewer.tsx
+++ b/frontend/src/components/document-viewer/document-viewer.tsx
@@ -1,9 +1,11 @@
+import { FileContent } from '@navikt/ds-icons';
 import { Loader } from '@navikt/ds-react';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { DocumentViewerContext, IViewedDocument } from '../../pages/create/document-viewer-context';
 import { KABIN_API_BASE_PATH } from '../../simple-api-state/use-api';
 import { Card } from '../card/card';
+import { Placeholder } from '../placeholder/placeholder';
 import { DocumentTitle } from './document-title';
 
 const DEFAULT_NAME = '<Mangler navn>';
@@ -13,33 +15,53 @@ export const DocumentViewer = () => {
 
   return (
     <Card fullHeight>
-      <DocumentTitle />
       <Container>
-        <StyledLoader size="3xlarge" />
-        <PDF {...dokument} />
+        <Content dokument={dokument} />
       </Container>
     </Card>
   );
 };
 
-const PDF = ({ journalpostId, dokumentInfoId, tittel: title }: IViewedDocument) => {
-  const url = `${KABIN_API_BASE_PATH}/journalposter/${journalpostId}/dokumenter/${dokumentInfoId}/pdf`;
+const Content = ({ dokument }: { dokument: IViewedDocument | null }) => {
+  if (dokument === null) {
+    return (
+      <Placeholder>
+        <FileContent aria-hidden />
+      </Placeholder>
+    );
+  }
+
+  const url = `${KABIN_API_BASE_PATH}/journalposter/${dokument.journalpostId}/dokumenter/${dokument.dokumentInfoId}/pdf`;
 
   return (
+    <>
+      <DocumentTitle url={url} />
+      <PDF tittel={dokument.tittel} url={url} />
+    </>
+  );
+};
+
+interface PDFProps {
+  url: string;
+  tittel: string | null;
+}
+
+const PDF = ({ url, tittel }: PDFProps) => (
+  <>
+    <StyledLoader size="3xlarge" />
     <StyledObject
       data={`${url}#toolbar=0&view=fitH&zoom=page-width`}
       role="document"
       type="application/pdf"
-      name={title ?? DEFAULT_NAME}
+      name={tittel ?? DEFAULT_NAME}
     />
-  );
-};
+  </>
+);
 
 const Container = styled.div`
   position: relative;
   width: 100%;
   border-radius: 4px;
-  background-color: var(--a-surface-neutral-subtle);
   flex-grow: 1;
 `;
 

--- a/frontend/src/components/document-viewer/edit-document-title.tsx
+++ b/frontend/src/components/document-viewer/edit-document-title.tsx
@@ -1,0 +1,143 @@
+import { Cancel, SuccessColored } from '@navikt/ds-icons';
+import { Button, TextField } from '@navikt/ds-react';
+import React, { useCallback, useContext, useState } from 'react';
+import styled from 'styled-components';
+import { editTitle } from '../../api/api';
+import { AnkeContext } from '../../pages/create/anke-context';
+import { DocumentViewerContext, IViewedDocument } from '../../pages/create/document-viewer-context';
+import { useDokumenter } from '../../simple-api-state/use-api';
+import { isApiError } from '../footer/error-type-guard';
+import { errorToast } from '../toast/error-toast';
+import { toast } from '../toast/store';
+import { ToastType } from '../toast/types';
+
+interface Props {
+  show: boolean;
+  toggleEditMode: () => void;
+}
+
+export const EditTitle = ({ show, toggleEditMode }: Props) => {
+  const { dokument } = useContext(DocumentViewerContext);
+
+  if (!show || dokument === null) {
+    return null;
+  }
+
+  return <EditLoadedTitle toggleEditMode={toggleEditMode} dokument={dokument} />;
+};
+
+interface EditLoadedTitleProps {
+  toggleEditMode: () => void;
+  dokument: IViewedDocument;
+}
+
+const EditLoadedTitle = ({ toggleEditMode, dokument }: EditLoadedTitleProps) => {
+  const { viewDokument } = useContext(DocumentViewerContext);
+  const { fnr, setDokument, dokument: contextDokument } = useContext(AnkeContext);
+
+  const { updateData: updateDokumenter } = useDokumenter(fnr);
+
+  const { tittel: title, dokumentInfoId, journalpostId } = dokument;
+
+  const [newTitle, setNewTitle] = useState(title ?? '');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onSaveClick = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const res = await editTitle(newTitle, journalpostId, dokumentInfoId);
+
+      if (res.ok) {
+        toast({ type: ToastType.SUCCESS, message: `Dokumenttittel endret` });
+
+        setDokument(contextDokument === null ? null : { ...contextDokument, tittel: newTitle });
+        viewDokument({ ...dokument, tittel: newTitle });
+
+        updateDokumenter((data) =>
+          data === undefined
+            ? undefined
+            : {
+                ...data,
+                dokumenter: data.dokumenter.map((doc) =>
+                  doc.journalpostId === journalpostId
+                    ? {
+                        ...doc,
+                        tittel: doc.dokumentInfoId === dokumentInfoId ? newTitle : doc.tittel,
+                        vedlegg: doc.vedlegg.map((v) =>
+                          v.dokumentInfoId === dokumentInfoId ? { ...v, tittel: newTitle } : v
+                        ),
+                      }
+                    : doc
+                ),
+              }
+        );
+      } else {
+        const json = (await res.json()) as unknown;
+
+        if (isApiError(json)) {
+          errorToast(json);
+        }
+      }
+    } catch (e) {
+      if (e instanceof Error) {
+        toast({ type: ToastType.ERROR, message: `Feil ved endring av dokumenttittel: ${e.message}` });
+      }
+    }
+
+    setIsLoading(false);
+    toggleEditMode();
+  }, [
+    toggleEditMode,
+    newTitle,
+    journalpostId,
+    dokumentInfoId,
+    setDokument,
+    contextDokument,
+    viewDokument,
+    dokument,
+    updateDokumenter,
+  ]);
+
+  const isChanged = title !== newTitle;
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        isChanged ? onSaveClick() : toggleEditMode();
+      }
+
+      if (e.key === 'Escape') {
+        toggleEditMode();
+      }
+    },
+    [isChanged, onSaveClick, toggleEditMode]
+  );
+
+  return (
+    <>
+      <StyledTextField
+        value={newTitle}
+        onChange={({ target }) => setNewTitle(target.value)}
+        label="Endre tittel"
+        size="small"
+        hideLabel
+        autoFocus
+        onKeyDown={onKeyDown}
+      />
+      <Button
+        variant="tertiary"
+        size="small"
+        icon={<SuccessColored title="Lagre" />}
+        onClick={isChanged ? onSaveClick : toggleEditMode}
+        loading={isLoading}
+      />
+      <Button variant="tertiary" size="small" icon={<Cancel title="Avbryt" />} onClick={toggleEditMode} />
+    </>
+  );
+};
+
+const StyledTextField = styled(TextField)`
+  width: 100%;
+  flex-grow: 1;
+`;

--- a/frontend/src/components/documents/attachment.tsx
+++ b/frontend/src/components/documents/attachment.tsx
@@ -17,7 +17,12 @@ export const Attachment = ({ vedlegg, dokument }: Props) => {
   const selectVedlegg = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      setDokument(dokument);
+
+      if (dokument.harTilgangTilArkivvariant) {
+        setDokument(dokument);
+      } else {
+        setDokument(null);
+      }
     },
     [dokument, setDokument]
   );

--- a/frontend/src/components/documents/document-title.tsx
+++ b/frontend/src/components/documents/document-title.tsx
@@ -19,8 +19,8 @@ export const DocumentTitle = ({ journalpostId, dokumentInfoId, tittel, harTilgan
   );
 
   const onInternalClick = useCallback(
-    () => viewDokument({ tittel, dokumentInfoId, journalpostId }),
-    [viewDokument, tittel, dokumentInfoId, journalpostId]
+    () => viewDokument(harTilgangTilArkivvariant ? { tittel, dokumentInfoId, journalpostId } : null),
+    [viewDokument, harTilgangTilArkivvariant, tittel, dokumentInfoId, journalpostId]
   );
 
   if (!harTilgangTilArkivvariant) {

--- a/frontend/src/components/documents/select-document.tsx
+++ b/frontend/src/components/documents/select-document.tsx
@@ -1,0 +1,44 @@
+import { SuccessColored, Warning } from '@navikt/ds-icons';
+import React from 'react';
+import styled from 'styled-components';
+import { GridArea, GridButton } from './styled-grid-components';
+
+interface Props {
+  isSelected: boolean;
+  selectJournalpost: (e: React.MouseEvent) => void;
+  harTilgangTilArkivvariant: boolean;
+}
+
+export const SelectDocument = ({ harTilgangTilArkivvariant, isSelected, selectJournalpost }: Props) => {
+  if (!harTilgangTilArkivvariant) {
+    return (
+      <StyledWarning>
+        <Warning title="Du har ikke tilgang til dette dokumentet" />
+      </StyledWarning>
+    );
+  }
+
+  const icon = isSelected ? <SuccessColored title="Valgt" /> : undefined;
+  const buttonText = isSelected ? '' : 'Velg';
+
+  return (
+    <GridButton
+      size="small"
+      variant="tertiary"
+      icon={icon}
+      onClick={selectJournalpost}
+      aria-pressed={isSelected}
+      data-testid="select-document"
+      $gridArea={GridArea.SELECT}
+    >
+      {buttonText}
+    </GridButton>
+  );
+};
+
+const StyledWarning = styled.div`
+  grid-area: ${GridArea.SELECT};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/components/footer/confirm.tsx
+++ b/frontend/src/components/footer/confirm.tsx
@@ -3,10 +3,11 @@ import { Alert, Button } from '@navikt/ds-react';
 import React, { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
+import { createAnke } from '../../api/api';
 import { ApiContext } from '../../pages/create/api-context';
-import { KABIN_API_BASE_PATH, useAnkemuligheter } from '../../simple-api-state/use-api';
+import { useAnkemuligheter } from '../../simple-api-state/use-api';
 import { skipToken } from '../../types/common';
-import { Create, CreateResponse } from '../../types/create';
+import { CreateResponse } from '../../types/create';
 import { errorToast } from '../toast/error-toast';
 import { toast } from '../toast/store';
 import { ToastType } from '../toast/types';
@@ -42,8 +43,6 @@ export const Confirm = ({ show, fnr, setError, closeConfirm }: Props) => {
       const res = await createAnke(payload);
 
       if (res.ok) {
-        toast({ type: ToastType.SUCCESS, message: `Anke opprettet` });
-
         updateAnkemuligheter((data) => data?.filter((d) => d.behandlingId !== payload.klagebehandlingId));
 
         setError(undefined);
@@ -98,13 +97,6 @@ export const Confirm = ({ show, fnr, setError, closeConfirm }: Props) => {
     </StyledConfirm>
   );
 };
-
-const createAnke = async (anke: Create) =>
-  fetch(`${KABIN_API_BASE_PATH}/createanke`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(anke),
-  });
 
 const StyledConfirm = styled.div`
   background: var(--a-surface-default);

--- a/frontend/src/components/overstyringer/overstyringer.tsx
+++ b/frontend/src/components/overstyringer/overstyringer.tsx
@@ -1,10 +1,13 @@
-import { Label, TextField, ToggleGroup } from '@navikt/ds-react';
+import { Detail, Label, Loader, TextField } from '@navikt/ds-react';
 import { parseISO } from 'date-fns';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import styled from 'styled-components';
+import { isoDateToPretty } from '../../domain/date';
 import { FieldNames } from '../../hooks/use-field-name';
 import { useValidationError } from '../../hooks/use-validation-error';
 import { AnkeContext } from '../../pages/create/anke-context';
+import { useCalculateFristdato } from '../../simple-api-state/use-api';
+import { skipToken } from '../../types/common';
 import { Card } from '../card/card';
 import { Datepicker } from '../date-picker/date-picker';
 import { Part } from './part';
@@ -12,10 +15,16 @@ import { PartRead } from './part-read';
 import { GridArea, gridAreas } from './types';
 
 export const Overstyringer = () => {
-  const { ankemulighet, klager, fullmektig, setKlager, setFullmektig } = useContext(AnkeContext);
+  const { setMottattNav, ankemulighet, klager, fullmektig, setKlager, setFullmektig } = useContext(AnkeContext);
+
+  useEffect(() => {
+    if (ankemulighet === null) {
+      setMottattNav(null);
+    }
+  }, [ankemulighet, setMottattNav]);
 
   return (
-    <Card>
+    <Card title="Tilpass anken">
       <Content>
         <EditMottattNAV />
         <EditFrist />
@@ -49,25 +58,23 @@ const EditMottattNAV = () => {
     [setMottattNav]
   );
 
-  const disabled = ankemulighet === null || dokument === null;
-
   return (
     <StyledDatepicker
-      label="Mottatt NAV"
+      label="Mottatt NAV Klageinstans"
       onChange={onChange}
-      value={parseISO(mottattNav)}
+      value={mottattNav === null ? undefined : parseISO(mottattNav)}
       size="small"
-      toDate={disabled ? undefined : parseISO(dokument.registrert)}
-      fromDate={disabled ? undefined : parseISO(ankemulighet.vedtakDate)}
+      toDate={dokument === null ? undefined : parseISO(dokument.registrert)}
+      fromDate={ankemulighet === null ? undefined : parseISO(ankemulighet.vedtakDate)}
       id={FieldNames.MOTTATT_NAV}
       error={error}
-      disabled={disabled}
+      disabled={dokument === null}
     />
   );
 };
 
 const EditFrist = () => {
-  const { fristInWeeks, setFristInWeeks, dokument, ankemulighet } = useContext(AnkeContext);
+  const { fristInWeeks, setFristInWeeks } = useContext(AnkeContext);
   const error = useValidationError(FieldNames.FRIST);
 
   const parseAndSet = useCallback(
@@ -84,10 +91,8 @@ const EditFrist = () => {
     [parseAndSet]
   );
 
-  const disabled = ankemulighet === null || dokument === null;
-
   return (
-    <Row>
+    <StyledEditFrist>
       <StyledTextField
         type="number"
         label="Frist i uker"
@@ -97,27 +102,34 @@ const EditFrist = () => {
         value={fristInWeeks}
         onChange={onInputChange}
         error={error}
-        disabled={disabled}
       />
-      <StyledToggleGroup value={fristInWeeks.toString(10)} onChange={parseAndSet} size="small">
-        <PresetButton value={6} />
-        <PresetButton value={8} />
-        <PresetButton value={12} />
-        <PresetButton value={16} />
-        <PresetButton value={20} />
-      </StyledToggleGroup>
-    </Row>
+      <Fristdato />
+    </StyledEditFrist>
   );
 };
 
-interface PresetButtonProps {
-  value: number;
-}
+const Fristdato = () => {
+  const { mottattNav, fristInWeeks } = useContext(AnkeContext);
+  const { data: fristdato, isLoading } = useCalculateFristdato(
+    mottattNav === null ? skipToken : { fromDate: mottattNav, fristInWeeks }
+  );
 
-const PresetButton = ({ value }: PresetButtonProps) => {
-  const valueAsString = value.toString(10);
+  if (mottattNav === null) {
+    return null;
+  }
 
-  return <ToggleGroup.Item value={valueAsString}>{valueAsString} uker</ToggleGroup.Item>;
+  return (
+    <StyledFristdato>
+      <Label size="small">Beregnet fristdato:</Label>
+      {isLoading ? (
+        <Loader size="xsmall" />
+      ) : (
+        <Detail>
+          <time dateTime={fristdato}>{isoDateToPretty(fristdato)}</time>
+        </Detail>
+      )}
+    </StyledFristdato>
+  );
 };
 
 const StyledDatepicker = styled(Datepicker)`
@@ -133,14 +145,15 @@ const StyledHeading = styled(Label)`
   grid-area: title;
 `;
 
-const Row = styled.div`
+const StyledEditFrist = styled.div`
   display: flex;
   flex-direction: row;
-  column-gap: 8px;
+  gap: 8px;
   grid-column: frist;
 `;
 
-const StyledToggleGroup = styled(ToggleGroup)`
-  white-space: nowrap;
-  align-self: flex-end;
+const StyledFristdato = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 `;

--- a/frontend/src/components/placeholder/placeholder.tsx
+++ b/frontend/src/components/placeholder/placeholder.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const Placeholder = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--a-border-subtle);
+  flex-grow: 1;
+  width: 100%;
+  height: 100%;
+  font-size: 200px;
+  padding: 32px;
+`;

--- a/frontend/src/components/selected/selected-ankemulighet.tsx
+++ b/frontend/src/components/selected/selected-ankemulighet.tsx
@@ -37,7 +37,7 @@ const RenderAnkemulighet = ({ ankemulighet, onClick }: RenderProps) => {
     <Card>
       <Header>
         <Heading size="small" level="1">
-          Valgt ankemulighet
+          Valgt vedtak
         </Heading>
         <Button
           size="small"

--- a/frontend/src/components/selected/selected-document.tsx
+++ b/frontend/src/components/selected/selected-document.tsx
@@ -38,7 +38,7 @@ const RenderDokument = ({ dokument, onClick }: RenderProps) => {
     <Card>
       <Header>
         <Heading size="small" level="1">
-          Valgt journalpost
+          Valgt anke
         </Heading>
         <Button
           size="small"

--- a/frontend/src/hooks/use-field-name.ts
+++ b/frontend/src/hooks/use-field-name.ts
@@ -4,7 +4,7 @@ export enum FieldNames {
 }
 
 const FIELD_NAMES: Record<FieldNames, string> = {
-  [FieldNames.MOTTATT_NAV]: 'Mottatt NAV',
+  [FieldNames.MOTTATT_NAV]: 'Mottatt NAV Klageinstans',
   [FieldNames.FRIST]: 'Frist',
 };
 

--- a/frontend/src/hooks/use-previous.ts
+++ b/frontend/src/hooks/use-previous.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const prevRef = useRef<T>();
+
+  useEffect(() => {
+    prevRef.current = value;
+  });
+
+  return prevRef.current;
+};

--- a/frontend/src/pages/create/anke-context.tsx
+++ b/frontend/src/pages/create/anke-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { IBehandling } from '../../types/behandling';
 import { IPart, skipToken } from '../../types/common';
 import { getCreatePayload } from '../../types/create';
@@ -11,13 +11,13 @@ interface IAnkeContext {
   dokument: IArkivertDocument | null;
   klager: IPart | null;
   fullmektig: IPart | null;
-  mottattNav: string; // Date
+  mottattNav: string | null; // Date
   fristInWeeks: number; // Number of weeks
-  setAnkemulighet: (value: IBehandling) => void;
-  setDokument: (value: IArkivertDocument) => void;
+  setAnkemulighet: (value: IBehandling | null) => void;
+  setDokument: (value: IArkivertDocument | null) => void;
   setKlager: (value: IPart | null) => void;
   setFullmektig: (value: IPart | null) => void;
-  setMottattNav: (value: string) => void;
+  setMottattNav: (value: string | null) => void;
   setFristInWeeks: (value: number) => void;
 }
 
@@ -44,51 +44,28 @@ export const AnkeContext = createContext<IAnkeContext>({
 interface Props {
   children: React.ReactNode;
   fnr: string | typeof skipToken;
-  defaultDokument: IArkivertDocument;
-  defaultAnkemulighet: IBehandling;
 }
 
-export const AnkeContextState = ({ fnr, defaultDokument, defaultAnkemulighet, children }: Props) => {
+export const AnkeContextState = ({ fnr, children }: Props) => {
   const { setPayload } = useContext(ApiContext);
-  const [ankemulighet, setInternalAnkemulighet] = useState<IBehandling>(defaultAnkemulighet);
-  const [dokument, setInternalDokument] = useState<IArkivertDocument>(defaultDokument);
-  const [klager, setInternalKlager] = useState<IPart>(defaultAnkemulighet.klager);
+  const [ankemulighet, setAnkemulighet] = useState<IBehandling | null>(null);
+  const [journalpost, setDokument] = useState<IArkivertDocument | null>(null);
+  const [klager, setKlager] = useState<IPart | null>(null);
   const [fullmektig, setFullmektig] = useState<IPart | null>(null);
-  const [mottattNav, setMottattNav] = useState<string>(defaultDokument.registrert);
+  const [mottattNav, setMottattNav] = useState<string | null>(null);
   const [fristInWeeks, setFristInWeeks] = useState<number>(12);
-
-  const klagebehandlingId = ankemulighet.behandlingId;
-  const ankeDocumentJournalpostId = dokument.journalpostId;
 
   useEffect(() => {
     const payload = getCreatePayload({
-      klagebehandlingId,
-      ankeDocumentJournalpostId,
+      journalpost,
+      ankemulighet,
       mottattNav,
       fristInWeeks,
       klager,
       fullmektig,
     });
     setPayload(payload);
-  }, [mottattNav, klager, fullmektig, setPayload, klagebehandlingId, ankeDocumentJournalpostId, fristInWeeks]);
-
-  const setKlager = useCallback(
-    (newKlager: IPart | null) => setInternalKlager(newKlager ?? ankemulighet.klager),
-    [ankemulighet.klager]
-  );
-
-  const setAnkemulighet = useCallback(
-    (newAnkemulighet: IBehandling) => {
-      setInternalAnkemulighet(newAnkemulighet);
-      setKlager(newAnkemulighet.klager);
-    },
-    [setKlager]
-  );
-
-  const setDokument = useCallback((newDokument: IArkivertDocument) => {
-    setInternalDokument(newDokument);
-    setMottattNav(newDokument.registrert);
-  }, []);
+  }, [mottattNav, klager, fullmektig, setPayload, fristInWeeks, journalpost, ankemulighet]);
 
   const ankeContext: IAnkeContext = {
     fnr,
@@ -102,7 +79,7 @@ export const AnkeContextState = ({ fnr, defaultDokument, defaultAnkemulighet, ch
     setMottattNav,
     fristInWeeks,
     setFristInWeeks,
-    dokument,
+    dokument: journalpost,
     setDokument,
   };
 

--- a/frontend/src/pages/create/create.tsx
+++ b/frontend/src/pages/create/create.tsx
@@ -1,9 +1,7 @@
-import { FileContent, FileFolder, Notes, Paragraph } from '@navikt/ds-icons';
-import { BodyShort, Loader } from '@navikt/ds-react';
+import { Loader } from '@navikt/ds-react';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Ankemuligheter } from '../../components/ankemuligheter/ankemuligheter';
-import { Card } from '../../components/card/card';
 import { DocumentViewer } from '../../components/document-viewer/document-viewer';
 import { Dokumenter } from '../../components/documents/documents';
 import { Footer } from '../../components/footer/footer';
@@ -11,9 +9,7 @@ import { Overstyringer } from '../../components/overstyringer/overstyringer';
 import { usePersonSearch } from '../../components/search/hook';
 import { PersonSearch } from '../../components/search/search';
 import { useAnkemuligheter, useDokumenter } from '../../simple-api-state/use-api';
-import { IBehandling } from '../../types/behandling';
 import { skipToken } from '../../types/common';
-import { IArkivertDocument } from '../../types/dokument';
 import { AnkeContextState } from './anke-context';
 import { ApiContextState } from './api-context';
 import { DocumentViewerContextState } from './document-viewer-context';
@@ -24,8 +20,8 @@ export const CreatePage = () => {
 
   const { search } = personSearch;
 
-  const { data: dokumenter, isLoading: dokumenterIsloading } = useDokumenter(search);
-  const { data: ankemuligheter, isLoading: ankemuligheterIsLoading } = useAnkemuligheter(search);
+  const { isLoading: dokumenterIsloading } = useDokumenter(search);
+  const { isLoading: ankemuligheterIsLoading } = useAnkemuligheter(search);
 
   const isLoading = dokumenterIsloading || ankemuligheterIsLoading;
 
@@ -36,13 +32,7 @@ export const CreatePage = () => {
       <ApiContextState>
         <StyledMain $isIinitialized={isInitialized}>
           <PersonSearch isInitialized={isInitialized} {...personSearch} />
-          <CreatePageLoader
-            showPlaceholders={isInitialized && (search === skipToken || isLoading)}
-            isLoading={isLoading}
-            dokumenter={dokumenter?.dokumenter}
-            ankemuligheter={ankemuligheter}
-            fnr={search}
-          />
+          <CreatePageLoader fnr={search} isInitialized={isInitialized} isLoading={isLoading} />
         </StyledMain>
         <Footer fnr={search} />
       </ApiContextState>
@@ -52,74 +42,25 @@ export const CreatePage = () => {
 
 interface LoaderProps {
   fnr: string | typeof skipToken;
-  dokumenter: IArkivertDocument[] | undefined;
-  ankemuligheter: IBehandling[] | undefined;
+  isInitialized: boolean;
   isLoading: boolean;
-  showPlaceholders: boolean;
 }
 
-const CreatePageLoader = ({ fnr, dokumenter, ankemuligheter, isLoading, showPlaceholders }: LoaderProps) => {
-  if (showPlaceholders) {
-    return (
-      <>
-        <LeftColumn>
-          <Card title="Dokumenter">
-            <Placeholder>
-              <FileFolder aria-hidden />
-            </Placeholder>
-          </Card>
-          <Card title="Ankemuligheter">
-            <Placeholder>
-              <Paragraph aria-hidden />
-            </Placeholder>
-          </Card>
-          <Card>
-            <Placeholder>
-              <Notes aria-hidden />
-            </Placeholder>
-          </Card>
-        </LeftColumn>
-        <RightColumn>
-          <Card title="Dokument" fullHeight>
-            <Placeholder>
-              <FileContent aria-hidden />
-            </Placeholder>
-          </Card>
-        </RightColumn>
-      </>
-    );
-  }
+const CreatePageLoader = ({ fnr, isLoading, isInitialized }: LoaderProps) => {
+  if (!isInitialized) {
+    if (isLoading) {
+      return <Loader size="3xlarge">Laster...</Loader>;
+    }
 
-  if (isLoading) {
-    return <Loader size="3xlarge">Laster...</Loader>;
-  }
-
-  if (typeof dokumenter === 'undefined' || typeof ankemuligheter === 'undefined') {
     return null;
   }
 
-  const [firstDokument] = dokumenter;
-  const [firstAnkemulighet] = ankemuligheter;
-
-  if (firstDokument === undefined || firstAnkemulighet === undefined) {
-    return (
-      <>
-        <LeftColumn>
-          <Card>
-            <BodyShort>Ingen dokumenter eller ingen ankemuligheter funnet</BodyShort>
-          </Card>
-        </LeftColumn>
-        <RightColumn />
-      </>
-    );
-  }
-
   return (
-    <AnkeContextState defaultAnkemulighet={firstAnkemulighet} defaultDokument={firstDokument} fnr={fnr}>
-      <DocumentViewerContextState initialDokument={firstDokument}>
+    <AnkeContextState fnr={fnr}>
+      <DocumentViewerContextState>
         <LeftColumn>
-          <Dokumenter dokumenter={dokumenter} />
-          <Ankemuligheter ankemuligheter={ankemuligheter} />
+          <Dokumenter />
+          <Ankemuligheter />
           <Overstyringer />
         </LeftColumn>
         <RightColumn>
@@ -178,20 +119,8 @@ const LeftColumn = styled(Column)`
 const RightColumn = styled(Column)`
   grid-area: right;
   max-width: 1500px;
-  min-width: 750px;
+  min-width: 500px;
   overflow: hidden;
   padding-right: 16px;
   padding-left: 8px;
-`;
-
-const Placeholder = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--a-border-subtle);
-  flex-grow: 1;
-  width: 100%;
-  height: 100%;
-  font-size: 200px;
-  padding: 32px;
 `;

--- a/frontend/src/pages/create/document-viewer-context.tsx
+++ b/frontend/src/pages/create/document-viewer-context.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { IArkivertDocument } from '../../types/dokument';
 
 interface IViewedDocumentId {
   journalpostId: string;
@@ -15,35 +14,26 @@ interface ISetViewedDocument extends IViewedDocumentId {
 }
 
 interface IDocumentViewerContext {
-  dokument: IViewedDocument;
-  viewDokument: (value: ISetViewedDocument) => void;
+  dokument: IViewedDocument | null;
+  viewDokument: (value: ISetViewedDocument | null) => void;
 }
 
 const DEFAULT_DOKUMENT_NAME = 'Ukjent dokumentnavn';
 
 export const DocumentViewerContext = React.createContext<IDocumentViewerContext>({
-  dokument: {
-    journalpostId: '',
-    dokumentInfoId: '',
-    tittel: DEFAULT_DOKUMENT_NAME,
-  },
+  dokument: null,
   viewDokument: () => {},
 });
 
 interface Props {
   children: React.ReactNode;
-  initialDokument: IArkivertDocument;
 }
 
-export const DocumentViewerContextState = ({ initialDokument, children }: Props) => {
-  const [dokument, setDokument] = useState<IViewedDocument>({
-    tittel: initialDokument.tittel ?? DEFAULT_DOKUMENT_NAME,
-    journalpostId: initialDokument.journalpostId,
-    dokumentInfoId: initialDokument.dokumentInfoId,
-  });
+export const DocumentViewerContextState = ({ children }: Props) => {
+  const [dokument, setDokument] = useState<IViewedDocument | null>(null);
 
-  const viewDokument = (value: ISetViewedDocument) =>
-    setDokument({ ...value, tittel: value.tittel ?? DEFAULT_DOKUMENT_NAME });
+  const viewDokument = (value: ISetViewedDocument | null) =>
+    setDokument(value === null ? null : { ...value, tittel: value.tittel ?? DEFAULT_DOKUMENT_NAME });
 
   return <DocumentViewerContext.Provider value={{ dokument, viewDokument }}>{children}</DocumentViewerContext.Provider>;
 };

--- a/frontend/src/pages/status/details.tsx
+++ b/frontend/src/pages/status/details.tsx
@@ -47,7 +47,7 @@ export const Details = ({
       </StyledCard>
 
       <StyledCard title="Saksinfo" $gridArea="anke" titleSize="medium">
-        <InfoItem label="Mottatt NAV">
+        <InfoItem label="Mottatt NAV Klageinstans">
           <Time dateTime={mottattNav}>{isoDateToPretty(mottattNav) ?? mottattNav}</Time>
         </InfoItem>
         <InfoItem label="Frist">

--- a/frontend/src/simple-api-state/use-api.ts
+++ b/frontend/src/simple-api-state/use-api.ts
@@ -70,3 +70,20 @@ export const useStatus = (params: StatusParams | typeof skipToken) => {
 
   return useSimpleApiState(state);
 };
+
+interface CalculateFristdatoParams {
+  fromDate: string; // LocalDate
+  fristInWeeks: number;
+}
+
+const calculateFristdatoState = getStateFactory<string, CalculateFristdatoParams>(
+  `${KABIN_API_BASE_PATH}/calculatefrist`,
+  { method: 'POST' }
+);
+
+export const useCalculateFristdato = (params: CalculateFristdatoParams | typeof skipToken) =>
+  useSimpleApiState(
+    params === skipToken
+      ? skipToken
+      : calculateFristdatoState({ path: '' }, { fromDate: params.fromDate, fristInWeeks: params.fristInWeeks })
+  );

--- a/frontend/src/types/create.ts
+++ b/frontend/src/types/create.ts
@@ -1,4 +1,6 @@
+import { IBehandling } from './behandling';
 import { IPart, IPartId, PartType } from './common';
+import { IArkivertDocument } from './dokument';
 
 export interface Create {
   klagebehandlingId: string;
@@ -9,16 +11,36 @@ export interface Create {
   ankeDocumentJournalpostId: string;
 }
 
-interface Argument extends Omit<Create, 'klager' | 'fullmektig'> {
-  klager: IPart;
+interface Argument {
+  klager: IPart | null;
   fullmektig: IPart | null;
+  journalpost: IArkivertDocument | null;
+  ankemulighet: IBehandling | null;
+  mottattNav: string | null;
+  fristInWeeks: number;
 }
 
-export const getCreatePayload = ({ klager, fullmektig, ...rest }: Argument): Create => ({
-  ...rest,
-  klager: getPart(klager),
-  fullmektig: getPart(fullmektig),
-});
+export const getCreatePayload = ({
+  klager,
+  fullmektig,
+  ankemulighet,
+  journalpost,
+  mottattNav,
+  fristInWeeks,
+}: Argument): Create | null => {
+  if (ankemulighet === null || journalpost === null || mottattNav === null) {
+    return null;
+  }
+
+  return {
+    klagebehandlingId: ankemulighet.behandlingId,
+    mottattNav,
+    fristInWeeks,
+    ankeDocumentJournalpostId: journalpost.journalpostId,
+    klager: getPart(klager),
+    fullmektig: getPart(fullmektig),
+  };
+};
 
 const getPart = (part: IPart | null): IPartId | null => {
   if (part === null) {


### PR DESCRIPTION
- Don't pre-choose document/ankemulighet
- Fix bug where document renaming would re-use name from previous renamed document
- Fix bug where "Valgt anke" (minimzed) would show old name for renamed document
- Don't let user (try to) pick or view PDF for document they don't have access to
- Show calculated frist date (based on mottatt NAV + frist in weeks)
- Add button to show PDF in new tab
- Rename "Mottatt NAV" -> "Mottatt NAV Klageinstans"
- Remove toast on sucessfully created anke (status page oughta be enough)
- Let PDF-view shrink more (when needed)
- Reword section titles
- Remove "quick buttons" for frist
- Replace "Velg" button with warning sign for documents that user does not have access to